### PR TITLE
GROSS-1358: SHA-pin GitHub Actions and enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       with: 
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@871f041373faaad213a635d9afb62905ec029bbb # v1.10.1
       with:
         dotnet-version: |
           7.0.x
@@ -28,7 +28,7 @@ jobs:
     - name: Test with dotnet test
       run: dotnet test --configuration Release --no-build
     - name: Nerdbank.GitVersioning
-      uses: dotnet/nbgv@master
+      uses: dotnet/nbgv@705dad19ab067f12f4e9eeaa60812e01edef5d25 # v0.5.2
       with:
         setAllVars: true
     - run: echo "Package generated artefacts/DotNetDockerTest.${NBGV_NuGetPackageVersion}.nupkg"


### PR DESCRIPTION
##  Prerequisite

Merge this PR to fix the build issue https://github.com/G-Research/DotNetDockerTest/pull/9

## What

Pin all GitHub Actions references to full commit SHAs (with trailing `# <version>` comments) and enable Dependabot for the `github-actions` ecosystem.

Ref: G-Research/gr-oss#1358

## Why

A mutable `@vN` / `@master` ref can be silently rewritten by the upstream maintainer (or a compromised account) and is picked up immediately by every workflow run. Pinning to an immutable commit SHA closes that supply-chain risk; the trailing `# <version>` comment keeps the pin human-readable. Dependabot is enabled so the pins are kept up to date automatically instead of going stale.

## Notes

- `dotnet/nbgv@master` was tracking a branch (mutable, no fixed version). It is now pinned to the latest nbgv release `v0.5.2`. This is a small behaviour change (branch tip → fixed release) but removes a moving, unpinnable reference.
- Other actions were pinned to their current major's SHA — a pin, not a version bump. Future upgrades are left to Dependabot.