### PR TITLE
fix: restore CI on ubuntu-24.04 (bump Nerdbank.GitVersioning + add .NET 8 for nbgv tool)

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -19,7 +19,9 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: |
+          7.0.x
+          8.0.x
     - name: Build with dotnet
       run: dotnet build --configuration Release
     - name: Test with dotnet test

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" PrivateAssets="All" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## What

Restore CI on `ubuntu-24.04` for this repo, which was failing in two places:

1. **`Nerdbank.GitVersioning` package** bumped `3.3.37` -> `3.6.133`. The old version bundled a `libgit2` that needs `libssl.so.1.1`, which `ubuntu-24.04` no longer ships, so `dotnet build` crashed with a `DllNotFoundException` / `TypeInitializationException` during version computation.

2. **Install .NET 8 in the workflow.** The `dotnet/nbgv` action installs the nbgv global CLI tool, which targets .NET 8, but `setup-dotnet` only installed .NET 7, so `nbgv get-version` failed to launch (`You must install or update .NET` -> exit 150). Now `setup-dotnet` installs `7.0.x` and `8.0.x`.

## Result

`dotnet build`, tests, packaging, and the `nbgv` version step all run on `ubuntu-24.04`.

## Notes

- Environmental/toolchain fixes only; no application or library code changed.
