### PR TITLE
Add .NET 10 so the nbgv tool can run on ubuntu-24.04

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -22,6 +22,7 @@ jobs:
         dotnet-version: |
           7.0.x
           8.0.x
+          10.0.x
     - name: Build with dotnet
       run: dotnet build --configuration Release
     - name: Test with dotnet test


### PR DESCRIPTION
## What

Add `10.0.x` to the `setup-dotnet` versions so the `dotnet/nbgv` step can run.

## Why

The `Nerdbank.GitVersioning` step fails on `ubuntu-24.04`:

```
nbgv get-version
You must install or update .NET to run this application.
Framework: 'Microsoft.NETCore.App', version '10.0.0'
exit code 150
```

The `dotnet/nbgv` action installs the latest `nbgv` global CLI tool, which now targets **.NET 10**, but the workflow only installed .NET 7 and 8, so the tool cannot launch. Adding `10.0.x` provides the runtime it needs.

## Notes

- This is the same class of issue as the earlier .NET 8 addition; the nbgv tool tracks the latest .NET, so the installed runtimes need to keep pace (a follow-up option would be to pin the nbgv tool version instead).
- Build/tooling change only; no application code touched.
